### PR TITLE
fix ドラゴン・アイス

### DIFF
--- a/c64262809.lua
+++ b/c64262809.lua
@@ -21,7 +21,8 @@ function c64262809.spcon(e,tp,eg,ep,ev,re,r,rp)
 	return eg:IsExists(c64262809.cfilter,1,nil,tp)
 end
 function c64262809.spcost(e,tp,eg,ep,ev,re,r,rp,chk)
-	local exc=(e:GetHandler():IsLocation(LOCATION_HAND) and not e:GetHandler():IsAbleToGraveAsCost()) and e:GetHandler() or nil
+	local c=e:GetHandler()
+	local exc=(c:IsLocation(LOCATION_HAND) and not c:IsAbleToGraveAsCost()) and c or nil
 	if chk==0 then return Duel.IsExistingMatchingCard(Card.IsDiscardable,tp,LOCATION_HAND,0,1,exc) end
 	Duel.DiscardHand(tp,Card.IsDiscardable,1,1,REASON_COST+REASON_DISCARD,exc)
 end
@@ -29,10 +30,10 @@ function c64262809.sptg(e,tp,eg,ep,ev,re,r,rp,chk)
 	if chk==0 then return Duel.GetLocationCount(tp,LOCATION_MZONE)>0
 		and e:GetHandler():IsCanBeSpecialSummoned(e,0,tp,false,false) end
 	Duel.SetOperationInfo(0,CATEGORY_SPECIAL_SUMMON,e:GetHandler(),1,0,0)
-	Duel.SetTargetCard(e:GetHandler())
 end
 function c64262809.spop(e,tp,eg,ep,ev,re,r,rp)
 	local c=e:GetHandler()
-	if not c:IsRelateToEffect(e) then return end
-	Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
+	if c:IsRelateToChain() or (c:IsLocation(LOCATION_GRAVE) and c:IsPreviousLocation(LOCATION_HAND) and c:GetReasonEffect()==e) then
+		Duel.SpecialSummon(c,0,tp,tp,false,false,POS_FACEUP)
+	end
 end


### PR DESCRIPTION
if ドラゴン・アイス discard self to activate its effect, 召喚獣メルカバー cannot banish it from GY.